### PR TITLE
[Feature / PD-420] Adapt Kansei Main to Remove Ros Arguments

### DIFF
--- a/src/kansei_main.cpp
+++ b/src/kansei_main.cpp
@@ -33,9 +33,13 @@
 
 int main(int argc, char * argv[])
 {
-  rclcpp::init(argc, argv);
+  auto args = rclcpp::init_and_remove_ros_arguments(argc, argv);
 
+<<<<<<< Updated upstream
   std::string port_name = "/dev/ttyUSB1";
+=======
+  std::string port_name = "/dev/serial/by-id/usb-Seeed_Seeed_XIAO_M0_E8D70AB55154305147202020FF050926-if00";
+>>>>>>> Stashed changes
   std::string path = "";
   kansei::fallen::DeterminantType determinant_type;
 
@@ -46,23 +50,23 @@ int main(int argc, char * argv[])
     "Optional:\n"
     "-h, --help           show this help message and exit\n";
 
-  if (argc > 1) {
-    for (int i = 1; i < argc; i++) {
-      std::string arg = argv[i];
+  if (args.size() > 1) {
+    for (int i = 1; i < args.size(); i++) {
+      std::string arg = args[i];
       if (arg == "-h" || arg == "--help") {
         std::cout << help_message << std::endl;
         return 1;
       } else if (arg == "--path") {
-        if (i + 1 < argc) {
-          path = argv[i + 1];
+        if (i + 1 < args.size()) {
+          path = args[i + 1];
           i++;
         } else {
           std::cerr << "Error: --path requires a path argument" << std::endl;
           return 1;
         }
       } else if (arg == "--type") {
-        if (i + 1 < argc) {
-          std::string fallen_type = argv[i + 1];
+        if (i + 1 < args.size()) {
+          std::string fallen_type = args[i + 1];
           if (fallen_type == "orientation") {
             determinant_type = kansei::fallen::DeterminantType::ORIENTATION;
           } else if (fallen_type == "accelero") {

--- a/src/kansei_main.cpp
+++ b/src/kansei_main.cpp
@@ -35,7 +35,7 @@ int main(int argc, char * argv[])
 {
   auto args = rclcpp::init_and_remove_ros_arguments(argc, argv);
 
-  std::string port_name = "/dev/serial/by-id/usb-Seeed_Seeed_XIAO_M0_E8D70AB55154305147202020FF050926-if00";
+  std::string port_name = "/dev/ttyUSB1";
   std::string path = "";
   kansei::fallen::DeterminantType determinant_type;
 
@@ -48,7 +48,7 @@ int main(int argc, char * argv[])
 
   if (args.size() > 1) {
     for (int i = 1; i < args.size(); i++) {
-      std::string arg = args[i];
+      const std::string& arg = args[i];
       if (arg == "-h" || arg == "--help") {
         std::cout << help_message << std::endl;
         return 1;
@@ -62,7 +62,7 @@ int main(int argc, char * argv[])
         }
       } else if (arg == "--type") {
         if (i + 1 < args.size()) {
-          std::string fallen_type = args[i + 1];
+          const std::string& fallen_type = args[i + 1];
           if (fallen_type == "orientation") {
             determinant_type = kansei::fallen::DeterminantType::ORIENTATION;
           } else if (fallen_type == "accelero") {

--- a/src/kansei_main.cpp
+++ b/src/kansei_main.cpp
@@ -35,11 +35,7 @@ int main(int argc, char * argv[])
 {
   auto args = rclcpp::init_and_remove_ros_arguments(argc, argv);
 
-<<<<<<< Updated upstream
-  std::string port_name = "/dev/ttyUSB1";
-=======
   std::string port_name = "/dev/serial/by-id/usb-Seeed_Seeed_XIAO_M0_E8D70AB55154305147202020FF050926-if00";
->>>>>>> Stashed changes
   std::string path = "";
   kansei::fallen::DeterminantType determinant_type;
 


### PR DESCRIPTION
## Jira Link: 
https://ichiro-its.atlassian.net/browse/PD-420
## Description

Adjust the main program of kansei to remove ros arguments because ros2 launch automatically appends --ros-args argument after all cmd arguments.

## Type of Change

- [ ] Bugfix
- [ ] Enhancement
- [X] New feature
- [ ] Breaking change (fix or feature that would cause the existing functionality to not work as expected)

## How Has This Been Tested?

- [ ] New unit tests added.
- [X] Manual tested.

## Checklist:

- [X] Using Branch Name Convention
    - `feature/JIRA-ID-SHORT-DESCRIPTION` if has a JIRA ticket
    - `enhancement/SHORT-DESCRIPTION` if has/has no JIRA ticket and contain enhancement
    - `hotfix/SHORT-DESCRIPTION` if the change doesn't need to be tested (urgent)
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made the documentation for the corresponding changes.